### PR TITLE
Ability to livestream HLS to Safari is working

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -24,12 +24,15 @@ export default function App() {
   function VideoDisplay(){
     return(
         <video width="620" controls 
-        src="https://archive.org/download/ElephantsDream/ed_hd.ogv" 
+        
         autoPlay
         style={{
         display:"block", 
         marginLeft:"auto", 
         marginRight:"auto"
-        }}></video>
+        }}>
+          <source src="http://localhost:3000/video/test/manifest.m3u8" type="application/x-mpegURL" />
+          {/* <source src="https://archive.org/download/ElephantsDream/ed_hd.ogv" type="video/ogg" /> */}
+        </video>
     )
   }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "webpack --config webpack.config.js",
     "dev-server": "nodemon ./frontend/server.js localhost 8000",
-    "dev-client": "webpack-dev-server --port 3000"
+    "dev-client": "webpack-dev-server --port 3030"
   },
   "author": "",
   "license": "ISC",
@@ -33,6 +33,8 @@
     "axios": "^1.6.2",
     "chalk": "^4",
     "express": "^4.18.2",
+    "ffmpeg": "^0.0.4",
+    "fluent": "^0.13.0",
     "fluent-ffmpeg": "^2.1.2",
     "lodash": "^4.17.21",
     "m3u8stream": "^0.8.6",


### PR DESCRIPTION
Added code to allow dev-client to serve livestreams while ingest and expressServer are running. It will read in order from manifest.m3u8 and should that be truncated it'll start from the top even if the files still exist.