### PR TITLE
Retrieved stream key prior to spinning up a new Ffmpeg Server

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -42,7 +42,8 @@ function HLSVideo() {
       }}
     >
       <source
-        src="http://localhost:3000/wavejs/mvp-demo/manifest.m3u8"
+        src="http://localhost:3000/wavejs/TestUser/manifest.m3u8"
+        //src="http://localhost:3000/wavejs/mvp-demo/manifest.m3u8"
         type="application/x-mpegURL"
       />
       {/* <source src="https://archive.org/download/ElephantsDream/ed_hd.ogv" type="video/ogg" /> */}
@@ -62,6 +63,7 @@ const ShakaWrapper = () => {
 
     async function loadAsset() {
       // Load an asset.
+      //await player.load('http://localhost:3000/wavejs/TestUser/manifest.mpd');
       await player.load('http://localhost:3000/wavejs/mvp-demo/manifest.mpd');
 
       // Trigger play.

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,60 +1,75 @@
 import React, { useRef, useEffect } from 'react';
 import ShakaPlayer from 'shaka-player-react';
-import { browserName } from "react-device-detect";;
-
+import { browserName } from 'react-device-detect';
 
 export default function App() {
-    return (
-      <div>
-        <h1 style={{display:"flex", alignItems:"center", justifyContent:"space-around"}}>Front End Proof of Concept</h1>
-        <div style={{display:"flex", alignItems:"center", justifyContent:"space-around"}}>We're putting a video player here</div>
-        
-        {browserName === 'Safari'?
-          <HLSVideo /> :
-          <ShakaWrapper />
-          }
-          
-      </div>
-    );
-  }
-
-
-  function HLSVideo(){
-    return(
-        <video width="620" controls 
-        autoPlay
+  return (
+    <div>
+      <h1
         style={{
-        display:"block", 
-        marginLeft:"auto", 
-        marginRight:"auto"
-        }}>
-          <source src="http://localhost:3000/wavejs/mvp-demo/manifest.m3u8" type="application/x-mpegURL" />
-          {/* <source src="https://archive.org/download/ElephantsDream/ed_hd.ogv" type="video/ogg" /> */}
-        </video>
-    )
-  }
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-around',
+        }}
+      >
+        Front End Proof of Concept
+      </h1>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-around',
+        }}
+      >
+        We're putting a video player here
+      </div>
 
+      {browserName === 'Safari' ? <HLSVideo /> : <ShakaWrapper />}
+    </div>
+  );
+}
 
-  const ShakaWrapper = () => {
-    const controllerRef = useRef(null);
+function HLSVideo() {
+  return (
+    <video
+      width="620"
+      controls
+      autoPlay
+      style={{
+        display: 'block',
+        marginLeft: 'auto',
+        marginRight: 'auto',
+      }}
+    >
+      <source
+        src="http://localhost:3000/wavejs/mvp-demo/manifest.m3u8"
+        type="application/x-mpegURL"
+      />
+      {/* <source src="https://archive.org/download/ElephantsDream/ed_hd.ogv" type="video/ogg" /> */}
+    </video>
+  );
+}
 
-    useEffect(() => {
-      const {
-        /** @type {shaka.Player} */ player,
-        /** @type {shaka.ui.Overlay} */ ui,
-        /** @type {HTMLVideoElement} */ videoElement
-      } = controllerRef.current;
-  
-      async function loadAsset() {
-        // Load an asset.
-        await player.load('http://localhost:3000/wavejs/mvp-demo/manifest.mpd');
-  
-        // Trigger play.
-        videoElement.play();
-      }
-  
-      loadAsset();
-    }, []);
-  
-    return <ShakaPlayer ref={controllerRef} />
-  }
+const ShakaWrapper = () => {
+  const controllerRef = useRef(null);
+
+  useEffect(() => {
+    const {
+      /** @type {shaka.Player} */ player,
+      /** @type {shaka.ui.Overlay} */ ui,
+      /** @type {HTMLVideoElement} */ videoElement,
+    } = controllerRef.current;
+
+    async function loadAsset() {
+      // Load an asset.
+      await player.load('http://localhost:3000/wavejs/mvp-demo/manifest.mpd');
+
+      // Trigger play.
+      videoElement.play();
+    }
+
+    loadAsset();
+  }, []);
+
+  return <ShakaPlayer ref={controllerRef} />;
+};

--- a/wavejs/ExpressServer.js
+++ b/wavejs/ExpressServer.js
@@ -59,26 +59,33 @@ class ExpressServer {
 
   dynamicRoute() {
     this.app.get(
-      `/${this.config.endpoint}/:streamId/:extension`,
+      `/${this.config.endpoint}/:streamKey/:extension`,
+      //`/${this.config.endpoint}/:streamId/:extension`,
       (req, res) => {
         //this is the area where we need to connect fmpg to the server
         Logger.debug(
-          `endpoint: ${this.config.endpoint}/${req.params.streamId}/${req.params.extension}`
+          `endpoint: ${this.config.endpoint}/${req.params.streamKey}/${req.params.extension}`
+          //`endpoint: ${this.config.endpoint}/${req.params.streamId}/${req.params.extension}`
         );
         const ext = req.params.extension.split('.')[1];
         let videoPath, streamPath;
         let contentType;
+        const streamId = this.session.activeLiveStreams.get(
+          req.params.streamKey
+        );
         // Logger.debug('stream: ', this.session.outputStreams)
         if (ext === 'm3u8' || ext === 'ts') {
           streamPath = this.session.getOutputStreamPath(
-            req.params.streamId,
+            streamId,
+            //req.params.streamId,
             'hls'
           );
           contentType = contentTypes['.m3u8'];
           videoPath = `${streamPath}/${req.params.extension}`;
         } else if (ext === 'mpd' || ext === 'm4s') {
           streamPath = this.session.getOutputStreamPath(
-            req.params.streamId,
+            streamId,
+            //req.params.streamId,
             'dash'
           );
           contentType = contentTypes['.mpd'];

--- a/wavejs/FFmpegServer.js
+++ b/wavejs/FFmpegServer.js
@@ -8,6 +8,7 @@ const streamStorage = require('./session');
 const streamConfig = {
   endpoint: 'live',
   streamId: 'test',
+  userId: 'testUser',
 };
 
 const videoAudioConfig = {
@@ -45,7 +46,10 @@ class FFmpegServer {
       `🎥 FFmpeg Server starting at rtmp://127.0.0.1:${this.port}`
       //`🎥 FFmpeg Server starting at rtmp://localhost/${this.streamConfig.endpoint}/${this.streamConfig.streamId}`
     );
-    this.session.initOutputStream(this.streamConfig.streamId);
+    this.session.initOutputStream(
+      this.streamConfig.streamId,
+      this.streamConfig.userId
+    );
     if (this.AVConfig.protocols.includes('hls')) {
       this.session.addOutputStream(this.streamConfig.streamId, 'hls');
       let HLSOutput = this.session.getOutputStreamPath(

--- a/wavejs/FFmpegServer.js
+++ b/wavejs/FFmpegServer.js
@@ -138,11 +138,12 @@ class FFmpegServer {
           'dash',
           false
         );
-        await this.session.deleteOutputStream(
-          this.streamConfig.streamId,
-          'dash'
-        );
-        process.exit(0);
+        /*COMMENT LINES 141 to 145 in to delete files after stream has ended */
+        // await this.session.deleteOutputStream(
+        //   this.streamConfig.streamId,
+        //   'dash'
+        // );
+        //process.exit(0);
       })
       // error handling
       .on('error', (err) => {
@@ -220,11 +221,12 @@ class FFmpegServer {
           'hls',
           false
         );
-        await this.session.deleteOutputStream(
-          this.streamConfig.streamId,
-          'hls'
-        );
-        process.exit(0);
+        /*COMMENT LINES 225 to 228 in to delete files after stream has ended */
+        // await this.session.deleteOutputStream(
+        //   this.streamConfig.streamId,
+        //   'hls'
+        // );
+        //process.exit(0);
       })
       // error handling
       .on('error', (err) => {

--- a/wavejs/fileController.js
+++ b/wavejs/fileController.js
@@ -1,20 +1,22 @@
 const path = require('node:path');
-const fs = require('node:fs/promises')
+const fs = require('node:fs/promises');
 const crypto = require('node:crypto');
 const { error, info } = require('./logger');
 
-
-
 class FileController {
-  constructor(streamId, mediaRoot = '../videoFiles') {
+  constructor(streamId, streamKey, mediaRoot = '../videoFiles') {
     this._mediaRoot = mediaRoot;
+    this.streamKey = streamKey;
     this._streamId;
     this.setStreamId(streamId);
   }
-    /* STREAM IDs */
+  /* STREAM IDs */
   setStreamId(newId) {
-    if (typeof newId !=='string') throw new Error(`FileController: only strings can be leveraged, not type '${typeof newId}'`)
-    this._streamId = newId
+    if (typeof newId !== 'string')
+      throw new Error(
+        `FileController: only strings can be leveraged, not type '${typeof newId}'`
+      );
+    this._streamId = newId;
   }
   getStreamId() {
     return this._streamId;
@@ -26,7 +28,13 @@ class FileController {
   }
   /* HLS Methods */
   buildHLSDirPath() {
-    return path.join(__dirname, this._mediaRoot, this._streamId, 'hls');
+    return path.join(
+      __dirname,
+      this._mediaRoot,
+      this.streamKey,
+      this._streamId,
+      'hls'
+    );
   }
   buildHLSPlaylistPath() {
     return path.join(this.buildHLSDirPath(), 'manifest.m3u8');
@@ -35,25 +43,30 @@ class FileController {
     const path = this.buildHLSDirPath();
     try {
       await fs.mkdir(path, { recursive: true });
-    } catch(err) {
+    } catch (err) {
       error(err);
     }
-    
   }
   async deleteHLSDir() {
     const path = this.buildHLSDirPath();
-    info(path)
+    info(path);
     try {
-      await fs.rm(path, {recursive: true, force: true});
-    } catch(err) {
-      error(err)
+      await fs.rm(path, { recursive: true, force: true });
+    } catch (err) {
+      error(err);
     }
-    info('deleteHLSDirCallled')
+    info('deleteHLSDirCallled');
   }
 
   /* MPD Methods */
   buildMPDDirPath() {
-    return path.join(__dirname, this._mediaRoot, this._streamId, 'mpd');
+    return path.join(
+      __dirname,
+      this._mediaRoot,
+      this.streamKey,
+      this._streamId,
+      'mpd'
+    );
   }
   buildMPDPlaylistPath() {
     return path.join(this.buildMPDDirPath(), 'manifest.mpd');
@@ -62,19 +75,18 @@ class FileController {
     const path = this.buildMPDDirPath();
     try {
       await fs.mkdir(path, { recursive: true });
-    } catch(err) {
+    } catch (err) {
       error(err);
     }
   }
   async deleteMPDDir() {
     const path = this.buildMPDDirPath();
     try {
-      await fs.rm(path, {recursive: true, force: true});
-    } catch(err) {
-      error(err)
+      await fs.rm(path, { recursive: true, force: true });
+    } catch (err) {
+      error(err);
     }
   }
-};
-
+}
 
 module.exports = FileController;

--- a/wavejs/rtmp-server/server.js
+++ b/wavejs/rtmp-server/server.js
@@ -105,12 +105,14 @@ const Server = () => {
     let ffmpegServer = undefined;
 
     streamStorage.events.on('publish', (args) => {
-      console.log('PATH!!!', args.stream_path);
+      // stream_path is /wavejs/streamkey => slice to isolate the stream key
+      let streamKey = args.stream_path.slice(8);
       ffmpegServer = new FFmpegServer(session, newPort);
       ffmpegServer.configureAV({ hlsListSize: ['-hls_list_size', '0'] });
       ffmpegServer.configureStream({
         endpoint: 'wavejs',
         streamId: String(state.id),
+        userId: streamKey,
       });
       ffmpegServer.listen();
 

--- a/wavejs/rtmp-server/server.js
+++ b/wavejs/rtmp-server/server.js
@@ -104,7 +104,7 @@ const Server = () => {
     let retry = true;
     let ffmpegServer = undefined;
 
-    streamStorage.events.on('publish', (args) => {
+    streamStorage.events.once('publish', (args) => {
       // stream_path is /wavejs/streamkey => slice to isolate the stream key
       let streamKey = args.stream_path.slice(8);
       ffmpegServer = new FFmpegServer(session, newPort);

--- a/wavejs/session.js
+++ b/wavejs/session.js
@@ -6,6 +6,8 @@ const streamStorage = {
   outputStreams: new Map(),
   supportedOutputFormats: ['dash', 'hls'],
   publishers: new Map(), // /LIVE/MY_COOL_STREAM, 3908f0_LIVE
+  // Track active live streams (each streamKey should only have 1 active live stream at a time)
+  activeLiveStreams: new Map(),
   ffmpegPorts: new Map(),
   /* FfmpegPort Methods */
   registerFfmpegPort(portNumber) {
@@ -31,6 +33,7 @@ const streamStorage = {
         },
       },
     });
+    this.activeLiveStreams.set(streamKey, streamId);
   },
   addOutputStream(streamId, protocol, active = true) {
     // Main error checking on protocol, active

--- a/wavejs/session.js
+++ b/wavejs/session.js
@@ -12,13 +12,9 @@ const streamStorage = {
     this.ffmpegPorts.set(String(portNumber), 'active port');
   },
   checkForActiveFfmpegPorts(portNumber) {
-    console.log(
-      'Is there an active port?',
-      this.ffmpegPorts.has(String(portNumber))
-    );
     return this.ffmpegPorts.has(String(portNumber));
-  },  events: new EventEmitter(),
-
+  },
+  events: new EventEmitter(),
 
   /* output Stream Methods */
   initOutputStream(streamId) {

--- a/wavejs/session.js
+++ b/wavejs/session.js
@@ -17,9 +17,9 @@ const streamStorage = {
   events: new EventEmitter(),
 
   /* output Stream Methods */
-  initOutputStream(streamId) {
+  initOutputStream(streamId, streamKey) {
     this.outputStreams.set(streamId, {
-      _fileController: new FileController(streamId),
+      _fileController: new FileController(streamId, streamKey),
       streams: {
         hls: {
           filePath: null,


### PR DESCRIPTION
In the RTMP server.js file, the stream key is now retrieved prior to spinning up a new Ffmpeg Server, and the stream key is now added to the streamConfig object. Each user has a unique stream key and all of their live streams will now be saved to their respective folder: 

wavejs/videoFiles/streamKey/streamId/HLS or MPEG / manifest and video chunks